### PR TITLE
Force fetch amd64 variant for amd64 image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM amd64/php:7.3-apache
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 # Install stuff Firefly III runs with & depends on: php extensions, locales, dev headers and composer


### PR DESCRIPTION
Changes in this pull request:

- If you would build this image on arm the "amd64" image would arm64 and not amd64.

@JC5
